### PR TITLE
Upgrade to YDB JDBC driver 2.0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ java_*.hprof*
 /nbdist/
 /.nb-gradle/
 build/
+nbactions-ydb.xml
+nbactions.xml
 
 ### VS Code ###
 .vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
                 <dependency>
                     <groupId>tech.ydb.jdbc</groupId>
                     <artifactId>ydb-jdbc-driver</artifactId>
-                    <version>2.0.0-SNAPSHOT</version>
+                    <version>2.0.7</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import tech.ydb.core.Status;
 import tech.ydb.core.StatusCode;
 import tech.ydb.core.UnexpectedResultException;
-import tech.ydb.jdbc.exception.YdbExecutionStatusException;
+import tech.ydb.jdbc.exception.YdbSQLException;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -532,10 +532,10 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                     break;
 
                 } catch (SQLException | UnexpectedResultException ex) {
-                    if  (ex instanceof YdbExecutionStatusException) {
+                    if  (ex instanceof YdbSQLException) {
                         YDB_ERRORS.tag("type", "any")
                                 .register(Metrics.globalRegistry).increment();
-                        YDB_ERRORS.tag("type", ((YdbExecutionStatusException)ex).getStatusCode().toString())
+                        YDB_ERRORS.tag("type", ((YdbSQLException)ex).getStatus().toString())
                                 .register(Metrics.globalRegistry).increment();
                     }
 
@@ -568,7 +568,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
                         if (retryCount <= maxRetryCount) {
                             status = TransactionStatus.RETRY;
-                            long sleepMs = backoffTimeMillis(((YdbExecutionStatusException)ex).getStatusCode(), retryCount);
+                            long sleepMs = backoffTimeMillis(((YdbSQLException)ex).getStatus().getCode(), retryCount);
                             try {
                                 Thread.sleep(sleepMs);
                             } catch (InterruptedException e) {

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
@@ -20,6 +20,7 @@ package com.oltpbenchmark.benchmarks.tpcc;
 
 import tech.ydb.jdbc.YdbConnection;
 
+import tech.ydb.core.UnexpectedResultException;
 import tech.ydb.table.SessionRetryContext;
 import tech.ydb.table.TableClient;
 import tech.ydb.table.values.ListType;
@@ -874,8 +875,8 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
                     ydbConnHelper.retryCtx.supplyStatus(session -> session.executeBulkUpsert(path, bulkData));
 
                 future.join().expectSuccess(String.format("bulk upsert problem, table: %s", tableName));
-            } catch (Exception e) {
-                LOG.error(String.format("Error executing bulk upsert, table: %s, exception: %s", tableName, e.getMessage()));
+            } catch (UnexpectedResultException e) {
+                LOG.debug(String.format("Error executing bulk upsert, table: %s, exception: %s", tableName, e.getMessage()));
                 throw new RuntimeException(e);
             }
         });
@@ -886,7 +887,7 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
             try {
                 statement.executeBatch();
                 statement.clearBatch();
-            } catch (Exception ex) {
+            } catch (SQLException ex) {
                 throw new RuntimeException(ex);
             }
         });
@@ -896,7 +897,7 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
         executeWithRetry(() -> {
             try {
                 statement.execute();
-            } catch (Exception ex) {
+            } catch (SQLException ex) {
                 throw new RuntimeException(ex);
             }
         });
@@ -906,7 +907,7 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
         executeWithRetry(() -> {
             try {
                 statement.executeUpdate();
-            } catch (Exception ex) {
+            } catch (SQLException ex) {
                 throw new RuntimeException(ex);
             }
         });

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
@@ -18,38 +18,21 @@
 
 package com.oltpbenchmark.benchmarks.tpcc;
 
-import tech.ydb.jdbc.connection.YdbContext;
-import tech.ydb.jdbc.exception.YdbConditionallyRetryableException;
-import tech.ydb.jdbc.exception.YdbRetryableException;
 import tech.ydb.jdbc.YdbConnection;
 
-import tech.ydb.core.Result;
-import tech.ydb.core.StatusCode;
-import tech.ydb.table.query.DataQueryResult;
-import tech.ydb.table.query.Params;
-import tech.ydb.table.result.ResultSetReader;
-import tech.ydb.table.Session;
 import tech.ydb.table.SessionRetryContext;
 import tech.ydb.table.TableClient;
-import tech.ydb.table.transaction.TxControl;
-
 import tech.ydb.table.values.ListType;
 import tech.ydb.table.values.ListValue;
-import tech.ydb.table.values.OptionalType;
-import tech.ydb.table.values.OptionalValue;
 import tech.ydb.table.values.PrimitiveType;
 import tech.ydb.table.values.PrimitiveValue;
 import tech.ydb.table.values.StructType;
-import tech.ydb.table.values.StructValue;
 import tech.ydb.table.values.Type;
 import tech.ydb.table.values.Value;
 
 import com.oltpbenchmark.api.Loader;
 import com.oltpbenchmark.api.LoaderThread;
 import com.oltpbenchmark.benchmarks.tpcc.pojo.*;
-import com.oltpbenchmark.catalog.Table;
-import com.oltpbenchmark.util.ThreadLocalRandomGenerator;
-import com.oltpbenchmark.util.SQLUtil;
 
 import java.time.Duration;
 import java.sql.*;
@@ -59,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * TPC-C Benchmark Loader
@@ -70,7 +52,7 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
     private static final int BACKOFF_CEILING = 5;
     private static final int MAX_RETRIES = 100;
 
-    private class YDBConnectionHelper {
+    public final class YDBConnectionHelper {
         private final YdbConnection ydbConn;
         private final TableClient tableClient;
         private final SessionRetryContext retryCtx;
@@ -538,7 +520,6 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
                 for (int d = 1; d <= districtsPerWarehouse; d++) {
                     for (int c = 1; c <= customersPerDistrict; c++) {
                         long millis = System.currentTimeMillis();
-                        Timestamp sysdate = new Timestamp(millis);
                         long ts = System.nanoTime();
                         if (ts <= prevTs) {
                             ts = prevTs + 1;


### PR DESCRIPTION
1. Update dependency on YDB JDBC to version 2.0.7
2. Convert the custom exception type from older `YdbExecutionStatusException` to `YdbSQLException`
3. Disable logging of retryable BulkUpsert errors on data load